### PR TITLE
Allow ignoring queries by name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby: [2.5, '3.0', head]
+        ruby: [2.6, '3.0']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    n_one (1.0.0)
+    n_one (1.0.1)
       pg_query
 
 GEM
@@ -23,6 +23,8 @@ GEM
     concurrent-ruby (1.1.8)
     factory_bot (6.1.0)
       activesupport (>= 5.0.0)
+    google-protobuf (3.19.1)
+    google-protobuf (3.19.1-x86_64-linux)
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
@@ -30,7 +32,8 @@ GEM
     parallel (1.20.1)
     parser (3.0.1.0)
       ast (~> 2.4.1)
-    pg_query (1.3.0)
+    pg_query (2.1.2)
+      google-protobuf (>= 3.17.1)
     pry (0.14.0)
       coderay (~> 1.1)
       method_source (~> 1.0)

--- a/README.md
+++ b/README.md
@@ -74,10 +74,22 @@ end
 Ignore notifications for call stacks containing one or more substrings:
 
 ```ruby
-  NOne.scan!(whitelist: 'myapp/lib/known_n_plus_ones/') do
+  NOne.scan!(whitelist: ['myapp/lib/known_n_plus_ones/']) do
     example.run
   end
 ```
+
+## Ignore names
+
+Ignore queries with names:
+
+```ruby
+  NOne.scan!(ignore_names: ['SCHEMA']) do
+    example.run
+  end
+```
+
+It will skip schema queries(e.g. for column names of a given table)
 
 ## Contributing
 

--- a/lib/n_one.rb
+++ b/lib/n_one.rb
@@ -30,11 +30,11 @@ module NOne
 
   module_function
 
-  def scan(whitelist: [], &block)
-    Runner.new(whitelist: whitelist).scan(&block)
+  def scan(**args, &block)
+    Runner.new(**args).scan(&block)
   end
 
-  def scan!(whitelist: [], &block)
-    Runner.new(whitelist: whitelist).scan!(&block)
+  def scan!(**args, &block)
+    Runner.new(**args).scan!(&block)
   end
 end

--- a/lib/n_one/runner.rb
+++ b/lib/n_one/runner.rb
@@ -2,8 +2,14 @@
 
 module NOne
   class Runner # :nodoc:
-    def initialize(whitelist: [])
+    # Instantiation
+    #
+    # @param whitelist [<String>] frame substrings to be ignored
+    # @param ignore_names [<String>] query names to be ignored
+    #
+    def initialize(whitelist: [], ignore_names: [])
       @whitelist = ['active_record/validations/uniqueness'] + whitelist
+      @ignore_names = ignore_names
     end
 
     def scan(&block)
@@ -20,7 +26,7 @@ module NOne
 
     private
 
-    attr_reader :store, :whitelist
+    attr_reader :store, :whitelist, :ignore_names
 
     def init_store
       @store = {}
@@ -51,6 +57,7 @@ module NOne
         cached = data[:cached]
 
         next if !sql.include?('SELECT') || cached
+        next if ignore_names.include?(data[:name])
 
         sql_fingerprint = Query.fingerprint(sql)
         next unless sql_fingerprint

--- a/lib/n_one/version.rb
+++ b/lib/n_one/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NOne
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end

--- a/test/test_queries.rb
+++ b/test/test_queries.rb
@@ -80,4 +80,16 @@ class TestQueries < Minitest::Test
       end
     end
   end
+
+  def test_ignore_schema_names
+    assert_raises NOne::NPlusOneDetected do
+      NOne.scan! do
+        10.times { ActiveRecord::Base.connection.execute('SELECT COUNT(*) FROM chairs', 'COUNTS') }
+      end
+    end
+
+    NOne.scan!(ignore_names: ['COUNTS']) do
+      10.times { ActiveRecord::Base.connection.execute('SELECT COUNT(*) FROM chairs', 'COUNTS') }
+    end
+  end
 end


### PR DESCRIPTION
Consider:

```rb
  def test_ignore_schema_names
    assert_raises NOne::NPlusOneDetected do
      NOne.scan! do
        10.times { ActiveRecord::Base.connection.execute('SELECT COUNT(*) FROM chairs', 'COUNTS') }
      end
    end

    NOne.scan!(ignore_names: ['COUNTS']) do
      10.times { ActiveRecord::Base.connection.execute('SELECT COUNT(*) FROM chairs', 'COUNTS') }
    end
  end
```

Useful for `SCHEMA` queries. Similar to this https://github.com/civiccc/db-query-matchers/blob/827993f5d4319a475273cc33699a1af5ea0131a4/lib/db_query_matchers/query_counter.rb#L44